### PR TITLE
Allow sf5 dependencies for console and finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     },
     "require": {
         "php": "~7.2",
-        "symfony/console": "^4.1",
-        "symfony/finder": "^4.1",
+        "symfony/console": "^4.1 || ^5.1",
+        "symfony/finder": "^4.1 || ^5.1",
         "twig/twig": "^2.5 || ^3",
         "ocramius/package-versions": "^1.3"
     },


### PR DESCRIPTION
This package is currently the only one holding me back on sf4 versions of console and finder so I quickly created this PR and of course tested it locally first - the tests and running it against the templates of project of mine.