### PR TITLE
Remove ocramius/package-versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "php": "~7.2",
         "symfony/console": "^4.1 || ^5.1",
         "symfony/finder": "^4.1 || ^5.1",
-        "twig/twig": "^2.5 || ^3",
-        "ocramius/package-versions": "^1.3"
+        "twig/twig": "^2.5 || ^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.3||^8.2",


### PR DESCRIPTION
The `ocramius/package-versions` package is not used in the project itself. However, it was required by one of the other packages. Since composer 2.0 was released, you can not install `sserbin/twig-linter` as `ocramius/package-versions` is incompatible. 

- I have remove `ocramius/package-versions`
- It has been replaced by `composer/package-versions-deprecated`