### PR TITLE
Replace ocramius/package-versions with composer/package-versions-deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/console": "^4.1 || ^5.1",
         "symfony/finder": "^4.1 || ^5.1",
         "twig/twig": "^2.5 || ^3",
-        "ocramius/package-versions": "^1.3"
+        "composer/package-versions-deprecated": "1.11.99.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.3||^8.2",


### PR DESCRIPTION
see https://github.com/sserbin/twig-linter/issues/24

This already happens when installing deps with dev packages as plsam (require-dev'd) requires `composer/package-versions-deprecated` but not with --no-dev installations