### PR TITLE
Update required versions of symfony console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     },
     "require": {
         "php": "^7.4|^8.0",
-        "symfony/console": "^4.1 || ^5.1",
-        "symfony/finder": "^4.1 || ^5.1",
+        "symfony/console": "^5.4 || ^6.1",
+        "symfony/finder": "^5.4 || ^6.1",
         "twig/twig": "^2.5 || ^3",
         "composer/package-versions-deprecated": "1.11.99.3"
     },


### PR DESCRIPTION
5.4 is the current supported LTS version, and 6.1 is the current active development version. Test suite still succeeds