### PR TITLE
fix twig 3.12 compat with failing to detect default function

### DIFF
--- a/src/StubEnvironment.php
+++ b/src/StubEnvironment.php
@@ -41,15 +41,12 @@ class StubEnvironment extends Environment
     public function getFunction($name): ?TwigFunction
     {
         /**
-         * @var string[]
          * @psalm-suppress InternalMethod
          */
-        $defaultFunctions = array_keys(parent::getFunctions());
-        $isDefault = isset($defaultFunctions[$name]);
+        $defaultFunction = parent::getFunction($name);
 
-        if ($isDefault) { // don't attempt to stub twig's builtin function
-            /** @psalm-suppress InternalMethod */
-            return parent::getFunction($name) ?: null;
+        if ($defaultFunction) { // don't attempt to stub twig's builtin function
+            return $defaultFunction;
         }
 
         return new TwigFunction((string)$name, $this->noop(), [


### PR DESCRIPTION
closes https://github.com/sserbin/twig-linter/issues/51

there was a change in getFunctions() between 3.11 and 3.12 - previously it returned array<int, string> and in 3.12 it changed the return format to be indexes by string (fn name) so the code broke a bit.

Simplified the code now to just check for getFunction() instead of relying on the internals of return value - this should work for both 3.11 and 3.12