### PR TITLE
Use Composer API for version information.

### DIFF
--- a/bin/twig-linter
+++ b/bin/twig-linter
@@ -2,9 +2,9 @@
 <?php
 declare(strict_types=1);
 
+use Composer\InstalledVersions;
 use Symfony\Component\Console\Application;
 use Twig\Loader\ArrayLoader;
-use PackageVersions\Versions;
 
 use Sserbin\TwigLinter\StubEnvironment;
 use Sserbin\TwigLinter\Command\LintCommand;
@@ -25,7 +25,11 @@ $twig = new StubEnvironment(new ArrayLoader, []);
 
 $lintCommand = new LintCommand($twig);
 
-$app = new Application('twig-linter', (string) Versions::getVersion('sserbin/twig-linter'));
+$packageName = 'sserbin/twig-linter';
+$version = InstalledVersions::getPrettyVersion($packageName);
+$reference = InstalledVersions::getReference($packageName);
+
+$app = new Application('twig-linter', $version . '@' . $reference);
 $app->add($lintCommand);
 $app->setDefaultCommand('lint');
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         "psr-4": { "Sserbin\\TwigLinter\\Tests\\": "tests/"}
     },
     "require": {
+        "composer-runtime-api": "^2.0",
         "php": "^7.4|^8.0",
         "symfony/console": "^5.4 || ^6.1",
         "symfony/finder": "^5.4 || ^6.1",
-        "twig/twig": "^2.5 || ^3",
-        "composer/package-versions-deprecated": "1.11.99.5"
+        "twig/twig": "^2.5 || ^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.3||^8.2|^9.5",


### PR DESCRIPTION
Replaces the depreceated "composer/package-versions-deprecated" with references to Composer's built-in version methods.

Requires composer v2 (which has been available since late 2020).